### PR TITLE
Add notification for holdtime expire

### DIFF
--- a/bgp/neighbor/neighbor.rb
+++ b/bgp/neighbor/neighbor.rb
@@ -163,6 +163,7 @@ module BGP
             Log.warn "#{type}"
             stop
           when :ev_holdtime_expire
+            changed and notify_observers(BGP::Notification.code_to_s(4))
             Log.warn "Holdtime expire: #{type}"
             stop
           else

--- a/bgp/neighbor/neighbor.rb
+++ b/bgp/neighbor/neighbor.rb
@@ -163,9 +163,9 @@ module BGP
             Log.warn "#{type}"
             stop
           when :ev_holdtime_expire
-            changed and notify_observers(BGP::Notification.code_to_s(4))
             Log.warn "Holdtime expire: #{type}"
             stop
+            changed and notify_observers(BGP::Notification.code_to_s(4))
           else
             Log.error "unexpected event #{ev}"
           end


### PR DESCRIPTION
Hi !

This is a small patch in order to get notification within the observer.  Indeed, when the server where bgp4r is running is unable to communicate with routers for any reason, the event isn't notify to the observer. In my case, it's important to know when bgp4r can't send information to routers.