### PR TITLE
Enable abort on exception in the eventQ

### DIFF
--- a/bgp/neighbor/neighbor.rb
+++ b/bgp/neighbor/neighbor.rb
@@ -135,6 +135,7 @@ module BGP
     end
 
     def event_dispatch
+      Thread::abort_on_exception = true
       Thread.new(@eventQ) do |eventQ|
         loop do
           ev, type, m = eventQ.deq


### PR DESCRIPTION
Enable abort on exception in the eventQ thread in order to handle specific exception. Typically use in my case when I want to raise a exception from an observer when a notification triggered (session timeout).